### PR TITLE
Now builds on both Open JDK and Oracle JDK.

### DIFF
--- a/Dockerfile.open-jdk
+++ b/Dockerfile.open-jdk
@@ -1,0 +1,24 @@
+FROM islandora/claw-maven:open-jdk
+MAINTAINER Nigel Banks <nigel.g.banks@gmail.com>
+
+LABEL "License"="MIT" \
+      "Version"="0.0.1"
+
+EXPOSE 8181
+
+ARG KARAF_VERSION="4.0.5"
+
+ENV KARAF_HOME="/opt/karaf" \
+    KARAF_OPTS="-Xms128M -Xmx512M -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass" \
+    PATH=${PATH}:/opt/karaf/bin
+
+RUN addgroup -g 1000 karaf && \
+    adduser -u 100 -s /sbin/nologin -G karaf -DH -h ${KARAF_HOME} karaf
+
+RUN apk-install openssh bash && \
+    curl -L http://archive.apache.org/dist/karaf/${KARAF_VERSION}/apache-karaf-${KARAF_VERSION}.tar.gz | \
+    tar -xzf - -C /tmp && \
+    mv /tmp/apache-karaf-${KARAF_VERSION} /opt/karaf && \
+    cleanup
+
+COPY rootfs /

--- a/Dockerfile.oracle-jdk
+++ b/Dockerfile.oracle-jdk
@@ -1,0 +1,24 @@
+FROM islandora/claw-maven:oracle-jdk
+MAINTAINER Nigel Banks <nigel.g.banks@gmail.com>
+
+LABEL "License"="MIT" \
+      "Version"="0.0.1"
+
+EXPOSE 8181
+
+ARG KARAF_VERSION="4.0.5"
+
+ENV KARAF_HOME="/opt/karaf" \
+    KARAF_OPTS="-Xms128M -Xmx512M -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass" \
+    PATH=${PATH}:/opt/karaf/bin
+
+RUN addgroup -g 1000 karaf && \
+    adduser -u 100 -s /sbin/nologin -G karaf -DH -h ${KARAF_HOME} karaf
+
+RUN apk-install openssh bash && \
+    curl -L http://archive.apache.org/dist/karaf/${KARAF_VERSION}/apache-karaf-${KARAF_VERSION}.tar.gz | \
+    tar -xzf - -C /tmp && \
+    mv /tmp/apache-karaf-${KARAF_VERSION} /opt/karaf && \
+    cleanup
+
+COPY rootfs /

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ For convenience a number of commands are provided in the [commands](/commands) f
 
 ## Notes
 
-Eventually we will support running on either OpenJDK or Oracle JDK, but for the moment it only supports Open JDK.
-
 If you experience issues with zombie Java processes not getting reaped, likely this is the result of a Kernel bug:
 
 * https://github.com/docker/docker/issues/18180

--- a/commands/build
+++ b/commands/build
@@ -1,3 +1,6 @@
 #!/bin/bash
-readonly DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-docker build -t islandora/claw-karaf $DIR/..
+readonly ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+docker build -f $ROOT/Dockerfile.oracle-jdk -t islandora/claw-karaf:oracle-jdk $ROOT
+docker build -f $ROOT/Dockerfile.open-jdk -t islandora/claw-karaf:open-jdk $ROOT
+# Open JDK is the default implementation. 
+docker tag islandora/claw-karaf:open-jdk islandora/claw-karaf:latest


### PR DESCRIPTION
We'll need to update Docker Hub once this is merged so it builds both Dockerfile's.
